### PR TITLE
Add verbose callsign sync option and paged update logging

### DIFF
--- a/HolyLogger/App.config
+++ b/HolyLogger/App.config
@@ -314,6 +314,9 @@
       <setting name="IsOverrideOperatorFromFile" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="CallsignSyncVerboseLog" serializeAs="String">
+        <value>True</value>
+      </setting>
     </HolyLogger.Properties.Settings>
   </userSettings>
 </configuration>

--- a/HolyLogger/MainWindow.xaml.cs
+++ b/HolyLogger/MainWindow.xaml.cs
@@ -2734,25 +2734,143 @@ namespace HolyLogger
             {
                 try
                 {
-                    string logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "callsign_update.log");
-                    File.AppendAllText(logPath, "Building URL with version: " + callsignListVersion.ToString(CultureInfo.InvariantCulture) + "\n");
+                    string baseDir = AppDomain.CurrentDomain.BaseDirectory;
+                    string logPath = Path.Combine(baseDir, "callsign_update.log");
+                    string traceLogPath = Path.Combine(baseDir, "callsign_sync_trace.log");
+                    bool verboseSyncTrace = Properties.Settings.Default.CallsignSyncVerboseLog;
 
-                    string url = "https://tools.iarc.org/holyland/server/getcallsign.php?version="
-                        + callsignListVersion.ToString(CultureInfo.InvariantCulture);
-                    
-                    File.AppendAllText(logPath, "URL: " + url + "\n");
-                    File.AppendAllText(logPath, "Making HTTP request...\n");
+                    // Keep trace log bounded by rolling it when it gets too large.
+                    try
+                    {
+                        if (verboseSyncTrace && File.Exists(traceLogPath))
+                        {
+                            var traceInfo = new FileInfo(traceLogPath);
+                            if (traceInfo.Length > (10 * 1024 * 1024))
+                            {
+                                string rolledPath = Path.Combine(
+                                    baseDir,
+                                    "callsign_sync_trace_" + DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + ".log");
+                                File.Move(traceLogPath, rolledPath);
+                            }
+                        }
+                    }
+                    catch { }
+
+                    Action<string> appendTrace = message =>
+                    {
+                        if (!verboseSyncTrace)
+                            return;
+
+                        try
+                        {
+                            File.AppendAllText(traceLogPath, message + "\n");
+                        }
+                        catch { }
+                    };
+
+                    appendTrace("============================================================");
+                    appendTrace("SYNC START " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+                    appendTrace("Initial local version: " + callsignListVersion.ToString(CultureInfo.InvariantCulture));
 
                     using (var client = new HttpClient())
                     {
                         client.Timeout = TimeSpan.FromSeconds(20);
-                        string serverReply = await client.GetStringAsync(url);
-                        
-                        File.AppendAllText(logPath, "Server reply received: " + serverReply.Substring(0, Math.Min(200, serverReply.Length)) + "...\n");
+                        const int maxBatches = 1000;
+                        int batchNumber = 0;
+                        bool hasMore;
 
-                        string updateResult = ApplyCallsignListUpdate(serverReply);
-                        
-                        File.AppendAllText(logPath, "Update result: " + updateResult + "\n");
+                        do
+                        {
+                            int requestVersion = callsignListVersion;
+                            File.AppendAllText(logPath, "Building URL with version: " + requestVersion.ToString(CultureInfo.InvariantCulture) + "\n");
+
+                            string url = "https://tools.iarc.org/holyland/server/getcallsign.php?version="
+                                + requestVersion.ToString(CultureInfo.InvariantCulture);
+
+                            appendTrace("---- BATCH " + (batchNumber + 1).ToString(CultureInfo.InvariantCulture) + " ----");
+                            appendTrace("Request time: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+                            appendTrace("Local version before request: " + requestVersion.ToString(CultureInfo.InvariantCulture));
+                            appendTrace("Request URL: " + url);
+
+                            File.AppendAllText(logPath, "URL: " + url + "\n");
+                            File.AppendAllText(logPath, "Making HTTP request...\n");
+
+                            string serverReply = await client.GetStringAsync(url);
+                            File.AppendAllText(logPath, "Server reply received: " + serverReply.Substring(0, Math.Min(200, serverReply.Length)) + "...\n");
+
+                            appendTrace("Raw server reply:");
+                            appendTrace(serverReply);
+
+                            var response = Newtonsoft.Json.Linq.JObject.Parse(serverReply);
+                            bool success = response["success"] != null && response["success"].ToObject<bool>();
+                            hasMore = response["hasMore"] != null && response["hasMore"].ToObject<bool>();
+                            int latestVersion = response["latestVersion"] != null
+                                ? response["latestVersion"].ToObject<int>()
+                                : -1;
+                            int itemCount = response["count"] != null
+                                ? response["count"].ToObject<int>()
+                                : ((response["data"] as Newtonsoft.Json.Linq.JArray)?.Count ?? 0);
+
+                            int addRequests = 0;
+                            int removeRequests = 0;
+                            var responseData = response["data"] as Newtonsoft.Json.Linq.JArray;
+                            if (responseData != null)
+                            {
+                                foreach (var row in responseData)
+                                {
+                                    int active = row["active"] != null ? row["active"].ToObject<int>() : 0;
+                                    if (active == 1)
+                                        addRequests++;
+                                    else if (active == -1)
+                                        removeRequests++;
+                                }
+                            }
+
+                            appendTrace(
+                                "Parsed reply: success=" + success.ToString(CultureInfo.InvariantCulture)
+                                + ", hasMore=" + hasMore.ToString(CultureInfo.InvariantCulture)
+                                + ", latestVersion=" + latestVersion.ToString(CultureInfo.InvariantCulture)
+                                + ", count=" + itemCount.ToString(CultureInfo.InvariantCulture));
+                            appendTrace(
+                                "Batch delta requests: adds=" + addRequests.ToString(CultureInfo.InvariantCulture)
+                                + ", removes=" + removeRequests.ToString(CultureInfo.InvariantCulture)
+                                + ", net=" + (addRequests - removeRequests).ToString(CultureInfo.InvariantCulture));
+
+                            string updateResult = ApplyCallsignListUpdate(serverReply);
+                            File.AppendAllText(logPath, "Update result: " + updateResult + "\n");
+                            appendTrace("Apply result: " + updateResult);
+                            appendTrace("Local version after apply: " + callsignListVersion.ToString(CultureInfo.InvariantCulture));
+
+                            if (updateResult.StartsWith("ERROR:", StringComparison.Ordinal))
+                            {
+                                appendTrace("Stopping sync because apply returned an error.");
+                                break;
+                            }
+
+                            batchNumber++;
+
+                            // Prevent infinite loops if the server reports hasMore without version progress.
+                            if (hasMore && callsignListVersion <= requestVersion)
+                            {
+                                File.AppendAllText(logPath, "ERROR: hasMore=true but version did not advance. Stopping to avoid loop.\n");
+                                appendTrace("Stopping sync because hasMore=true but version did not advance.");
+                                break;
+                            }
+
+                            if (batchNumber >= maxBatches)
+                            {
+                                File.AppendAllText(logPath, "ERROR: Reached max batches (" + maxBatches.ToString(CultureInfo.InvariantCulture) + "). Stopping.\n");
+                                appendTrace("Stopping sync because max batch limit was reached: " + maxBatches.ToString(CultureInfo.InvariantCulture));
+                                break;
+                            }
+
+                            appendTrace("Will request next batch: " + hasMore.ToString(CultureInfo.InvariantCulture));
+                        } while (hasMore);
+
+                        File.AppendAllText(logPath, "Update process finished after " + batchNumber.ToString(CultureInfo.InvariantCulture) + " batch(es).\n");
+                        appendTrace("SYNC END " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+                        appendTrace("Final local version: " + callsignListVersion.ToString(CultureInfo.InvariantCulture));
+                        appendTrace("Batches completed: " + batchNumber.ToString(CultureInfo.InvariantCulture));
 
                         // Keep startup UI quiet: no popup and no status bar updates.
                     }
@@ -2765,6 +2883,15 @@ namespace HolyLogger
                     try
                     {
                         File.AppendAllText(logPath, "ERROR: " + msg + "\n");
+
+                        if (Properties.Settings.Default.CallsignSyncVerboseLog)
+                        {
+                            string traceLogPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "callsign_sync_trace.log");
+                            File.AppendAllText(
+                                traceLogPath,
+                                "SYNC ERROR " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+                                + " - " + msg + "\n");
+                        }
                     }
                     catch { }
                     
@@ -2792,6 +2919,17 @@ namespace HolyLogger
                 var callsignSet = new HashSet<string>(StringComparer.Ordinal);
                 var fileLines = File.ReadAllLines(callsignFilePath);
                 int newVersion = callsignListVersion;
+                bool hasLatestVersion = false;
+
+                if (response["latestVersion"] != null)
+                {
+                    int parsedLatestVersion;
+                    if (int.TryParse(response["latestVersion"].ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out parsedLatestVersion))
+                    {
+                        newVersion = parsedLatestVersion;
+                        hasLatestVersion = true;
+                    }
+                }
 
                 foreach (var line in fileLines.Skip(1))
                 {
@@ -2807,6 +2945,8 @@ namespace HolyLogger
                 if (dataArray == null)
                     return "ERROR: Invalid data array in response";
 
+                int lastItemVersion = 0;
+
                 foreach (var item in dataArray)
                 {
                     string callsign = (item["callsign"]?.ToString() ?? "").ToUpperInvariant();
@@ -2821,8 +2961,11 @@ namespace HolyLogger
                             callsignSet.Remove(callsign);
                     }
 
-                    newVersion = version;
+                    lastItemVersion = version;
                 }
+
+                if (!hasLatestVersion && lastItemVersion > 0)
+                    newVersion = lastItemVersion;
 
                 var sortedCallsigns = callsignSet.ToList();
                 sortedCallsigns.Sort(StringComparer.Ordinal);

--- a/HolyLogger/MainWindow.xaml.cs
+++ b/HolyLogger/MainWindow.xaml.cs
@@ -2724,7 +2724,12 @@ namespace HolyLogger
             // Log immediately at startup
             try
             {
-                string logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "callsign_update.log");
+                string logDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "HolyLogger",
+                    "Logs");
+                Directory.CreateDirectory(logDir);
+                string logPath = Path.Combine(logDir, "callsign_update.log");
                 File.WriteAllText(logPath, "Update process started at " + DateTime.Now.ToString() + "\n");
             }
             catch { }
@@ -2734,9 +2739,13 @@ namespace HolyLogger
             {
                 try
                 {
-                    string baseDir = AppDomain.CurrentDomain.BaseDirectory;
-                    string logPath = Path.Combine(baseDir, "callsign_update.log");
-                    string traceLogPath = Path.Combine(baseDir, "callsign_sync_trace.log");
+                    string logDir = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "HolyLogger",
+                        "Logs");
+                    Directory.CreateDirectory(logDir);
+                    string logPath = Path.Combine(logDir, "callsign_update.log");
+                    string traceLogPath = Path.Combine(logDir, "callsign_sync_trace.log");
                     bool verboseSyncTrace = Properties.Settings.Default.CallsignSyncVerboseLog;
 
                     // Keep trace log bounded by rolling it when it gets too large.
@@ -2748,7 +2757,7 @@ namespace HolyLogger
                             if (traceInfo.Length > (10 * 1024 * 1024))
                             {
                                 string rolledPath = Path.Combine(
-                                    baseDir,
+                                    logDir,
                                     "callsign_sync_trace_" + DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture) + ".log");
                                 File.Move(traceLogPath, rolledPath);
                             }
@@ -2878,15 +2887,20 @@ namespace HolyLogger
                 catch (Exception ex)
                 {
                     string msg = "Callsign update request failed: " + ex.Message;
-                    
-                    string logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "callsign_update.log");
+
+                    string logDir = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "HolyLogger",
+                        "Logs");
+                    string logPath = Path.Combine(logDir, "callsign_update.log");
                     try
                     {
+                        Directory.CreateDirectory(logDir);
                         File.AppendAllText(logPath, "ERROR: " + msg + "\n");
 
                         if (Properties.Settings.Default.CallsignSyncVerboseLog)
                         {
-                            string traceLogPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "callsign_sync_trace.log");
+                            string traceLogPath = Path.Combine(logDir, "callsign_sync_trace.log");
                             File.AppendAllText(
                                 traceLogPath,
                                 "SYNC ERROR " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)

--- a/HolyLogger/OptionsUserControls/GeneralSettingsControl.xaml
+++ b/HolyLogger/OptionsUserControls/GeneralSettingsControl.xaml
@@ -11,21 +11,22 @@
         <CheckBox x:Name="CBX_IsAllowLiveLog" Content="Allow automatic upload during special events" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.isAllowLiveLog, Source={StaticResource Settings}, Mode=TwoWay}" Margin="0,26,0,0" FontSize="16"/>
         <CheckBox x:Name="CBX_ShowOnTheAir" Content="Show me in HolyLogger On The Air" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.ShowOnTheAir, Source={StaticResource Settings}, Mode=TwoWay}" Margin="0,51,0,0" FontSize="16"/>
         <CheckBox x:Name="CBX_EnableOmniRigCAT" Content="Enable Omni-Rig CAT" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.EnableOmniRigCAT, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16" Margin="0,76,0,0" Click="CBX_EnableOmniRigCAT_Changed"/>
+        <CheckBox x:Name="CBX_CallsignSyncVerboseLog" Content="Verbose callsign sync log (request/reply trace)" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.CallsignSyncVerboseLog, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16" Margin="0,101,0,0"/>
 
-        <GroupBox x:Name="groupBox" Header="Select Rig" Height="90" Margin="10,101,10,0" VerticalAlignment="Top" Width="360" FontSize="16">
+        <GroupBox x:Name="groupBox" Header="Select Rig" Height="90" Margin="10,126,10,0" VerticalAlignment="Top" Width="360" FontSize="16">
             <StackPanel>
                 <RadioButton x:Name="Rig1_RB" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Content="1: Rig Number 1"  Click="HasChanged_Click" IsChecked="{Binding Default.SelectedOmniRig1, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16"/>
                 <RadioButton x:Name="Rig2_RB" HorizontalAlignment="Left" Margin="0,8,0,0" VerticalAlignment="Top" Content="2: Rig Number 2" Click="HasChanged_Click" IsChecked="{Binding Default.SelectedOmniRig2, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16"/>
             </StackPanel>
         </GroupBox>
 
-        <CheckBox x:Name="CBX_EnableUDPClient" Content="Enable UDP Client" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.EnableUDPClient, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16" Margin="0,205,0,0" Click="HasChanged_Click"/>
-        <Label x:Name="label" Content="Port" HorizontalAlignment="Left" Margin="199,199,0,0" VerticalAlignment="Top" FontSize="16"/>
-        <TextBox x:Name="textBox" HorizontalAlignment="Left" Height="23" Margin="243,203,0,0" TextWrapping="Wrap" Text="{Binding Default.UDPPort, Mode=TwoWay, Source={StaticResource Settings}}" VerticalAlignment="Top" Width="112" FontSize="16" PreviewTextInput="PreviewTextInputHandler" DataObject.Pasting="PastingHandler" MaxLength="5" />
+        <CheckBox x:Name="CBX_EnableUDPClient" Content="Enable UDP Client" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.EnableUDPClient, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16" Margin="0,230,0,0" Click="HasChanged_Click"/>
+        <Label x:Name="label" Content="Port" HorizontalAlignment="Left" Margin="199,224,0,0" VerticalAlignment="Top" FontSize="16"/>
+        <TextBox x:Name="textBox" HorizontalAlignment="Left" Height="23" Margin="243,228,0,0" TextWrapping="Wrap" Text="{Binding Default.UDPPort, Mode=TwoWay, Source={StaticResource Settings}}" VerticalAlignment="Top" Width="112" FontSize="16" PreviewTextInput="PreviewTextInputHandler" DataObject.Pasting="PastingHandler" MaxLength="5" />
 
-        <CheckBox x:Name="CBX_EnableN1MMUDPClient" Content="N1MM+ UDP Client" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.EnableN1MMUDPClient, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16" Margin="0,230,0,0" Click="HasChanged_Click"/>
-        <Label x:Name="label2" Content="Port" HorizontalAlignment="Left" Margin="199,224,0,0" VerticalAlignment="Top" FontSize="16"/>
-        <TextBox x:Name="textBox2" HorizontalAlignment="Left" Height="23" Margin="243,229,0,0" TextWrapping="Wrap" Text="{Binding Default.N1MMUDPPort, Mode=TwoWay, Source={StaticResource Settings}}" VerticalAlignment="Top" Width="112" FontSize="16" PreviewTextInput="PreviewTextInputHandler" DataObject.Pasting="PastingHandler" MaxLength="5" />
+        <CheckBox x:Name="CBX_EnableN1MMUDPClient" Content="N1MM+ UDP Client" HorizontalAlignment="Left" VerticalAlignment="Top" IsChecked="{Binding Default.EnableN1MMUDPClient, Mode=TwoWay, Source={StaticResource Settings}}" FontSize="16" Margin="0,255,0,0" Click="HasChanged_Click"/>
+        <Label x:Name="label2" Content="Port" HorizontalAlignment="Left" Margin="199,249,0,0" VerticalAlignment="Top" FontSize="16"/>
+        <TextBox x:Name="textBox2" HorizontalAlignment="Left" Height="23" Margin="243,254,0,0" TextWrapping="Wrap" Text="{Binding Default.N1MMUDPPort, Mode=TwoWay, Source={StaticResource Settings}}" VerticalAlignment="Top" Width="112" FontSize="16" PreviewTextInput="PreviewTextInputHandler" DataObject.Pasting="PastingHandler" MaxLength="5" />
 
 
 

--- a/HolyLogger/Properties/Settings.Designer.cs
+++ b/HolyLogger/Properties/Settings.Designer.cs
@@ -1129,6 +1129,18 @@ namespace HolyLogger.Properties {
 
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool CallsignSyncVerboseLog {
+            get {
+                return ((bool)(this["CallsignSyncVerboseLog"]));
+            }
+            set {
+                this["CallsignSyncVerboseLog"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("1.15")]
         public double MapAutoFitMargin {
             get {

--- a/HolyLogger/Properties/Settings.settings
+++ b/HolyLogger/Properties/Settings.settings
@@ -278,6 +278,9 @@
     <Setting Name="ShowOnTheAir" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="CallsignSyncVerboseLog" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
     <Setting Name="MapAutoFitMargin" Type="System.Double" Scope="User">
       <Value Profile="(Default)">1.15</Value>
     </Setting>

--- a/HolyLogger_installer.nsi
+++ b/HolyLogger_installer.nsi
@@ -2,7 +2,7 @@
 ; Installs HolyLogger to Program Files and creates Start Menu + Desktop shortcuts
 
 !define APPNAME "HolyLogger"
-!define APPVERSION "8.4.3"
+!define APPVERSION "8.4.4"
 !define MANUFACTURER "4Z1KD"
 !define INSTALL_DIR "$PROGRAMFILES\${MANUFACTURER}\${APPNAME}"
 !define SOURCE_DIR "HolyLogger\bin\x86\Release"

--- a/HolyLogger_installer.nsi
+++ b/HolyLogger_installer.nsi
@@ -2,7 +2,7 @@
 ; Installs HolyLogger to Program Files and creates Start Menu + Desktop shortcuts
 
 !define APPNAME "HolyLogger"
-!define APPVERSION "8.4.2"
+!define APPVERSION "8.4.3"
 !define MANUFACTURER "4Z1KD"
 !define INSTALL_DIR "$PROGRAMFILES\${MANUFACTURER}\${APPNAME}"
 !define SOURCE_DIR "HolyLogger\bin\x86\Release"

--- a/VersionInfo.cs
+++ b/VersionInfo.cs
@@ -9,5 +9,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.4.2")]
-[assembly: AssemblyFileVersion("8.4.2")]
+[assembly: AssemblyVersion("8.4.3")]
+[assembly: AssemblyFileVersion("8.4.3")]

--- a/VersionInfo.cs
+++ b/VersionInfo.cs
@@ -9,5 +9,5 @@ using System.Reflection;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("8.4.3")]
-[assembly: AssemblyFileVersion("8.4.3")]
+[assembly: AssemblyVersion("8.4.4")]
+[assembly: AssemblyFileVersion("8.4.4")]


### PR DESCRIPTION
## Summary
- add General options checkbox for verbose callsign sync trace logging
- support paged callsign updates using hasMore
- support latestVersion in server response with fallback behavior
- keep startup UI silent while logging to files

## Validation
- HolyLogger Debug x86 rebuild passed
- Release installer built: HolyLogger_8.4.3_Setup.exe